### PR TITLE
Do not expect CWD to be passed for config

### DIFF
--- a/asyncpg_migrate/loader.py
+++ b/asyncpg_migrate/loader.py
@@ -11,10 +11,9 @@ from asyncpg_migrate import exceptions
 from asyncpg_migrate import model
 
 
-def load_configuration(cwd: Path, filename: str = 'migrations.ini') -> model.Config:
+def load_configuration(filename: Path) -> model.Config:
     logger.debug(
-        'Loading configuration from {path}/{filename}',
-        path=cwd,
+        'Loading configuration from {filename}',
         filename=filename,
     )
 
@@ -22,7 +21,7 @@ def load_configuration(cwd: Path, filename: str = 'migrations.ini') -> model.Con
         defaults=os.environ,
         interpolation=configparser.ExtendedInterpolation(),
     )
-    parser.read(cwd / filename)
+    parser.read(filename)
 
     user = parser.get('migrations', 'db_user')
     password = parser.get('migrations', 'db_password')
@@ -30,8 +29,12 @@ def load_configuration(cwd: Path, filename: str = 'migrations.ini') -> model.Con
     port = parser.getint('migrations', 'db_port')
     database_name = parser.get('migrations', 'db_name')
 
+    script_location = Path(parser.get('migrations', 'script_location'))
+    if not script_location.is_absolute():
+        script_location = Path.cwd() / script_location
+
     return model.Config(
-        script_location=cwd / parser.get('migrations', 'script_location'),
+        script_location=script_location,
         database_dsn=f'postgres://{user}:{password}@{host}:{port}/{database_name}',
         database_name=database_name,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,94 @@
+import datetime as dt
+from pathlib import Path
+import typing as t
+
+import pytest
+import pytest_mock as ptm
+
+from asyncpg_migrate import model
+
+
+@pytest.fixture(
+    params=[
+        'relative',
+        'absolute',
+    ],
+)
+def config_env(
+        tmp_path: Path,
+        request: t.Any,
+        config_with_migrations: t.Tuple[Path, model.Config, int],
+) -> t.Tuple[Path, Path, t.Dict[str, str]]:
+    script_location, _, _ = config_with_migrations
+    cf = tmp_path / str(dt.datetime.utcnow())
+    cf.touch(exist_ok=False)
+
+    configuration = [
+        '[migrations]',
+        f'script_location = {script_location}',
+        'db_user = ${postgres_user}',
+        'db_password = ${postgres_password}',
+        'db_host = ${postgres_host}',
+        'db_port = ${postgres_port}',
+        'db_name = ${postgres_database}',
+    ]
+    cf.write_text('\n'.join(configuration))
+
+    environ = {
+        'postgres_user': 'me',
+        'postgres_password': 'strong',
+        'postgres_host': 'database',
+        'postgres_port': '6666',
+        'postgres_database': 'internal',
+    }
+
+    cf_path = cf.absolute()
+    if request.param == 'relative':
+        cf_path = Path(
+            '/'.join(['..' for _ in range(len(cf.absolute().parents) + 1)]) + str(cf),
+        )
+
+    return cf_path, script_location, environ
+
+
+@pytest.fixture(
+    params=[
+        'relative',
+        'absolute',
+    ],
+)
+def config_with_migrations(
+        tmp_path: Path,
+        mocker: ptm.MockFixture,
+        request: t.Any,
+) -> t.Tuple[Path, model.Config, int]:
+    migrations_count = 10
+    script_location = tmp_path
+    if request.param == 'relative':
+        script_location = Path(
+            '/'.join(['..' for _ in range(len(
+                script_location.absolute().parents,
+            ) + 1)]) + str(tmp_path),
+        )
+
+    files = [(script_location / f'migration_{i}.py') for i in range(migrations_count)]
+    for i, f in enumerate(files):
+        f.touch(exist_ok=False)
+        f.write_text(
+            '\n'.join([
+                '',
+                f'revision = {i+1}',
+                '',
+                'async def upgrade():',
+                '    ...',
+                '',
+                'async def downgrade():',
+                '    ...',
+            ]),
+        )
+
+    return script_location, model.Config(
+        script_location=tmp_path,
+        database_name=mocker.stub(),
+        database_dsn=mocker.stub(),
+    ), migrations_count

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,7 +88,7 @@ def config_with_migrations(
         )
 
     return script_location, model.Config(
-        script_location=tmp_path,
+        script_location=script_location,
         database_name=mocker.stub(),
         database_dsn=mocker.stub(),
     ), migrations_count

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,108 +1,35 @@
-import datetime as dt
 from pathlib import Path
 import typing as t
 
-import pytest
 import pytest_mock as ptm
 
 from asyncpg_migrate import model
 
-EnvironValues = t.Dict[str, str]
-
-
-@pytest.fixture(
-    params=[
-        'relative',
-        'absolute',
-    ],
-)
-def config_env(
-        tmp_path_factory: t.Any,
-        request: t.Any,
-) -> t.Tuple[Path, EnvironValues]:
-    tmp_path = tmp_path_factory.mktemp(__name__)
-    cf = tmp_path / str(dt.datetime.utcnow())
-    cf.touch(exist_ok=False)
-
-    configuration = [
-        '[migrations]',
-        'script_location = funky_service/migrations',
-        'db_user = ${postgres_user}',
-        'db_password = ${postgres_password}',
-        'db_host = ${postgres_host}',
-        'db_port = ${postgres_port}',
-        'db_name = ${postgres_database}',
-    ]
-    cf.write_text('\n'.join(configuration))
-
-    environ: EnvironValues = {
-        'postgres_user': 'me',
-        'postgres_password': 'strong',
-        'postgres_host': 'database',
-        'postgres_port': '6666',
-        'postgres_database': 'internal',
-    }
-
-    cf_path = cf.absolute()
-    if request.param == 'relative':
-        cf_path = Path(
-            '/'.join(['..' for _ in range(len(cf.absolute().parents) + 1)]) + str(cf),
-        )
-
-    return cf_path, environ
-
-
-@pytest.fixture
-def config_with_migrations(
-        tmp_path: t.Any,
-        mocker: ptm.MockFixture,
-) -> t.Tuple[model.Config, int]:
-    migrations_count = 10
-    files = [(tmp_path / f'migration_{i}.py') for i in range(migrations_count)]
-    for i, f in enumerate(files):
-        f.touch(exist_ok=False)
-        f.write_text(
-            '\n'.join([
-                '',
-                f'revision = {i+1}',
-                '',
-                'async def upgrade():',
-                '    ...',
-                '',
-                'async def downgrade():',
-                '    ...',
-            ]),
-        )
-
-    return model.Config(
-        script_location=tmp_path,
-        database_name=mocker.stub(),
-        database_dsn=mocker.stub(),
-    ), migrations_count
-
 
 def test_load_configuration_env(
-        config_env: t.Tuple[Path, EnvironValues],
+        config_env: t.Tuple[Path, Path, t.Dict[str, str]],
         mocker: ptm.MockFixture,
 ) -> None:
     from asyncpg_migrate import loader
 
     mocker.patch.dict(
         'os.environ',
-        config_env[1],
+        config_env[2],
     )
     config = loader.load_configuration(filename=config_env[0])
 
-    assert config.database_name == config_env[1]['postgres_database']
+    assert config.database_name == config_env[2]['postgres_database']
     assert config.database_dsn
     assert config.script_location
 
 
-def test_load_migrations(config_with_migrations: t.Tuple[model.Config, int]) -> None:
+def test_load_migrations(
+        config_with_migrations: t.Tuple[Path, model.Config, int],
+) -> None:
     from asyncpg_migrate import loader
 
-    config = config_with_migrations[0]
-    migrations_count = config_with_migrations[1]
+    config = config_with_migrations[1]
+    migrations_count = config_with_migrations[2]
 
     migrations = loader.load_migrations(config)
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -20,7 +20,7 @@ def test_load_configuration_env(
 
     assert config.database_name == config_env[2]['postgres_database']
     assert config.database_dsn
-    assert config.script_location
+    assert config.script_location == Path.cwd() / config_env[1]
 
 
 def test_load_migrations(


### PR DESCRIPTION
Having `cwd` inside of the loader configuration function
proved to be difficult to implement passing configuration file in CLI.

Required-By: #42