### PR TITLE
Specify default section in configuration

### DIFF
--- a/asyncpg_migrate/loader.py
+++ b/asyncpg_migrate/loader.py
@@ -19,6 +19,7 @@ def load_configuration(filename: Path) -> model.Config:
 
     parser = configparser.ConfigParser(
         defaults=os.environ,
+        default_section='migrations',
         interpolation=configparser.ExtendedInterpolation(),
     )
     parser.read(filename)


### PR DESCRIPTION
Tools assumes reading from configuration file via `migrations` section